### PR TITLE
works around nuget change

### DIFF
--- a/src/GetStartedDotnet/GetStartedDotnet.csproj
+++ b/src/GetStartedDotnet/GetStartedDotnet.csproj
@@ -7,6 +7,8 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>GetStartedDotnet</AssemblyName>
     <OutputType>Exe</OutputType>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);NU1605</NoWarn>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
NuGet made a breaking change around downgrades warnings in the latest release see NuGet/Home#5594